### PR TITLE
Add `gtfs::source` to handle all parsing and general storage

### DIFF
--- a/include/gtfs.h
+++ b/include/gtfs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "gtfs/csv_parser.h"
+
 #include "gtfs/agency.h"
 #include "gtfs/calendar.h"
 #include "gtfs/calendar_date.h"
@@ -14,3 +15,5 @@
 #include "gtfs/stop_time.h"
 #include "gtfs/transfer.h"
 #include "gtfs/trip.h"
+
+#include "gtfs/source.h"

--- a/include/gtfs/agency.h
+++ b/include/gtfs/agency.h
@@ -2,15 +2,10 @@
 
 #include <ostream>
 
-#include "gtfs/csv_parser.h"
-
 
 namespace gtfs {
   class agency {
     public:
-      static csv_parser<agency> parser;
-      static std::string file_name;
-
       // Unique identifier for the agency
       std::string id;
       // Humanized name of the agency
@@ -42,16 +37,4 @@ namespace gtfs {
           << "\tPhone: " << a.phone << "\n";
       };
   };
-
-  std::string agency::file_name = "agency.txt";
-  csv_parser<agency> agency::parser = {{
-    { "agency_id",        make_field_mapper(&agency::id)       },
-    { "agency_name",      make_field_mapper(&agency::name)     },
-    { "agency_url",       make_field_mapper(&agency::url)      },
-    { "agency_timezone",  make_field_mapper(&agency::timezone) },
-    { "agency_lang",      make_field_mapper(&agency::language) },
-    { "agency_phone",     make_field_mapper(&agency::phone)    },
-    { "agency_fare_url",  make_field_mapper(&agency::fare_url) },
-    { "agency_email",     make_field_mapper(&agency::email)    }
-  }};
 }

--- a/include/gtfs/calendar.h
+++ b/include/gtfs/calendar.h
@@ -2,15 +2,10 @@
 
 #include <ostream>
 
-#include "gtfs/csv_parser.h"
-
 
 namespace gtfs {
   class calendar {
     public:
-      static csv_parser<calendar> parser;
-      static std::string file_name;
-
       // Identifier for the service this calendar record affects.
       std::string service_id;
       // Indication of service on the given day.
@@ -39,18 +34,4 @@ namespace gtfs {
           << "\tEnd Date: " << c.end_date << "\n";
       };
   };
-
-  std::string calendar::file_name = "calendar.txt";
-  csv_parser<calendar> calendar::parser = {{
-    { "service_id",  make_field_mapper(&calendar::service_id)  },
-    { "monday",      make_field_mapper(&calendar::monday)      },
-    { "tuesday",     make_field_mapper(&calendar::tuesday)     },
-    { "wednesday",   make_field_mapper(&calendar::wednesday)   },
-    { "thursday",    make_field_mapper(&calendar::thursday)    },
-    { "friday",      make_field_mapper(&calendar::friday)      },
-    { "saturday",    make_field_mapper(&calendar::saturday)    },
-    { "sunday",      make_field_mapper(&calendar::sunday)      },
-    { "start_date",  make_field_mapper(&calendar::start_date)  },
-    { "end_date",    make_field_mapper(&calendar::end_date)    }
-  }};
 }

--- a/include/gtfs/calendar_date.h
+++ b/include/gtfs/calendar_date.h
@@ -2,15 +2,10 @@
 
 #include <ostream>
 
-#include "gtfs/csv_parser.h"
-
 
 namespace gtfs {
   class calendar_date {
     public:
-      static csv_parser<calendar_date> parser;
-      static std::string file_name;
-
       // Identifier for the service affected by this calendar date
       std::string service_id;
       // Date for which the service exception applies
@@ -29,11 +24,4 @@ namespace gtfs {
           << "\tException Type: " << cd.exception_type << "\n";
       };
   };
-
-  std::string calendar_date::file_name = "calendar_dates.txt";
-  csv_parser<calendar_date> calendar_date::parser = {{
-    { "service_id",     make_field_mapper(&calendar_date::service_id)     },
-    { "date",           make_field_mapper(&calendar_date::date)           },
-    { "exception_type", make_field_mapper(&calendar_date::exception_type) }
-  }};
 }

--- a/include/gtfs/csv_parser.h
+++ b/include/gtfs/csv_parser.h
@@ -19,31 +19,30 @@ namespace gtfs {
     using header_list_t = std::vector<std::string>;
 
 
-    std::string file = T::file_name;
+    std::string file_path;
     type_map_t field_types;
 
-    std::string   archive_dir;
     std::ifstream input;
     header_list_t headers;
 
 
     public:
       csv_parser() = default;
-      csv_parser(type_map_t type_map) {
+      csv_parser(std::string file, type_map_t type_map) {
+        this->file_path   = file;
         this->field_types = type_map;
       };
 
-      void initialize(std::string directory) {
-        this->archive_dir = directory;
+      void initialize() {
         this->input.clear();
         this->input.close();
-        this->input.open(directory + "/" + this->file);
+        this->input.open(this->file_path);
         this->headers = _parse_headers();
       }
 
-      object_list_t all(std::string directory) {
+      object_list_t all() {
         object_list_t list;
-        initialize(directory);
+        initialize();
         std::string row;
         while(std::getline(this->input, row)) list.push_back(_parse_line(row));
         finish();

--- a/include/gtfs/fare_attribute.h
+++ b/include/gtfs/fare_attribute.h
@@ -2,15 +2,10 @@
 
 #include <ostream>
 
-#include "gtfs/csv_parser.h"
-
 
 namespace gtfs {
   class fare_attribute {
     public:
-      static csv_parser<fare_attribute> parser;
-      static std::string file_name;
-
       // Identifier for the fare these attributes affect
       std::string fare_id;
       // Price of the fare
@@ -38,14 +33,4 @@ namespace gtfs {
           << "\tTransfer Duration: " << fa.transfer_duration << "\n";
       };
   };
-
-  std::string fare_attribute::file_name = "fare_attributes.txt";
-  csv_parser<fare_attribute> fare_attribute::parser = {{
-    { "fare_id",           make_field_mapper(&fare_attribute::fare_id)           },
-    { "price",             make_field_mapper(&fare_attribute::price)             },
-    { "currency_type",     make_field_mapper(&fare_attribute::currency_type)     },
-    { "payment_method",    make_field_mapper(&fare_attribute::payment_method)    },
-    { "transfers",         make_field_mapper(&fare_attribute::transfers)         },
-    { "transfer_duration", make_field_mapper(&fare_attribute::transfer_duration) },
-  }};
 }

--- a/include/gtfs/fare_rule.h
+++ b/include/gtfs/fare_rule.h
@@ -2,15 +2,10 @@
 
 #include <ostream>
 
-#include "gtfs/csv_parser.h"
-
 
 namespace gtfs {
   class fare_rule {
     public:
-      static csv_parser<fare_rule> parser;
-      static std::string file_name;
-
       // Identifier for the fare this rule affect
       std::string fare_id;
       // Route this fare rule affects
@@ -35,13 +30,4 @@ namespace gtfs {
           << "\tcontains_id: " << fr.contains_id << "\n";
       };
   };
-
-  std::string fare_rule::file_name = "fare_rules.txt";
-  csv_parser<fare_rule> fare_rule::parser = {{
-    { "fare_id",         make_field_mapper(&fare_rule::fare_id)        },
-    { "route_id",        make_field_mapper(&fare_rule::route_id)       },
-    { "origin_id",       make_field_mapper(&fare_rule::origin_id)      },
-    { "destination_id",  make_field_mapper(&fare_rule::destination_id) },
-    { "contains_id",     make_field_mapper(&fare_rule::contains_id)    }
-  }};
 }

--- a/include/gtfs/feed_info.h
+++ b/include/gtfs/feed_info.h
@@ -2,15 +2,10 @@
 
 #include <ostream>
 
-#include "gtfs/csv_parser.h"
-
 
 namespace gtfs {
   class feed_info {
     public:
-      static csv_parser<feed_info> parser;
-      static std::string file_name;
-
       // Name of the entity publishing this feed
       std::string publisher_name;
       // URL for the publishing entity
@@ -38,14 +33,4 @@ namespace gtfs {
           << "\tVersion: " << fi.version << "\n";
       };
   };
-
-  std::string feed_info::file_name = "feed_info.txt";
-  csv_parser<feed_info> feed_info::parser = {{
-    { "feed_publisher_name", make_field_mapper(&feed_info::publisher_name) },
-    { "feed_publisher_url",  make_field_mapper(&feed_info::publisher_url)  },
-    { "feed_lang",           make_field_mapper(&feed_info::language)       },
-    { "feed_start_date",     make_field_mapper(&feed_info::start_date)     },
-    { "feed_end_date",       make_field_mapper(&feed_info::end_date)       },
-    { "feed_version",        make_field_mapper(&feed_info::version)        }
-  }};
 }

--- a/include/gtfs/frequency.h
+++ b/include/gtfs/frequency.h
@@ -2,15 +2,10 @@
 
 #include <ostream>
 
-#include "gtfs/csv_parser.h"
-
 
 namespace gtfs {
   class frequency {
     public:
-      static csv_parser<frequency> parser;
-      static std::string file_name;
-
       // Trip this frequency applies to
       std::string trip_id;
       // Time at which service at this frequency begins
@@ -35,13 +30,4 @@ namespace gtfs {
           << "\tExact Timing: " << f.exact_times << "\n";
       };
   };
-
-  std::string frequency::file_name = "frequencies.txt";
-  csv_parser<frequency> frequency::parser = {{
-    { "trip_id",       make_field_mapper(&frequency::trip_id)     },
-    { "start_time",    make_field_mapper(&frequency::start_time)  },
-    { "end_time",      make_field_mapper(&frequency::end_time)    },
-    { "headway_secs",  make_field_mapper(&frequency::headway)     },
-    { "exact_times",   make_field_mapper(&frequency::exact_times) }
-  }};
 }

--- a/include/gtfs/route.h
+++ b/include/gtfs/route.h
@@ -2,15 +2,10 @@
 
 #include <ostream>
 
-#include "gtfs/csv_parser.h"
-
 
 namespace gtfs {
   class route {
     public:
-      static csv_parser<route> parser;
-      static std::string file_name;
-
       // Unique identifier for the route
       std::string id;
       // Identifier of the Agency that owns the route
@@ -45,17 +40,4 @@ namespace gtfs {
           << "\tText Color: " << r.text_color << "\n";
       };
   };
-
-  std::string route::file_name = "routes.txt";
-  csv_parser<route> route::parser = {{
-    { "route_id",         make_field_mapper(&route::id)           },
-    { "agency_id",        make_field_mapper(&route::agency_id)    },
-    { "route_short_name", make_field_mapper(&route::short_name)   },
-    { "route_long_name",  make_field_mapper(&route::long_name)    },
-    { "route_desc",       make_field_mapper(&route::description)  },
-    { "route_url",        make_field_mapper(&route::url)          },
-    { "route_type",       make_field_mapper(&route::type)         },
-    { "route_color",      make_field_mapper(&route::color)        },
-    { "route_text_color", make_field_mapper(&route::text_color)   }
-  }};
 }

--- a/include/gtfs/shape.h
+++ b/include/gtfs/shape.h
@@ -2,15 +2,10 @@
 
 #include <ostream>
 
-#include "gtfs/csv_parser.h"
-
 
 namespace gtfs {
   class shape {
     public:
-      static csv_parser<shape> parser;
-      static std::string file_name;
-
       // Unique identifier for a shape
       std::string id;
       // Latitude of this point in the shape
@@ -34,13 +29,4 @@ namespace gtfs {
           << "\tDistance: " << s.distance << "\n";
       };
   };
-
-  std::string shape::file_name = "shapes.txt";
-  csv_parser<shape> shape::parser = {{
-    { "shape_id",            make_field_mapper(&shape::id)         },
-    { "shape_pt_lat",        make_field_mapper(&shape::latitude)   },
-    { "shape_pt_lon",        make_field_mapper(&shape::longitude)  },
-    { "shape_pt_sequence",   make_field_mapper(&shape::index)      },
-    { "shape_dist_traveled", make_field_mapper(&shape::distance)   }
-  }};
 }

--- a/include/gtfs/source.h
+++ b/include/gtfs/source.h
@@ -149,35 +149,35 @@ namespace gtfs {
       };
 
       // Parser objects for each type defined by GTFS.
-      csv_parser<agency> agency;
-      csv_parser<calendar> calendar;
-      csv_parser<calendar_date> calendar_dates;
-      csv_parser<fare_attribute> fare_attributes;
-      csv_parser<fare_rule> fare_rules;
-      csv_parser<feed_info> feed_info;
-      csv_parser<frequency> frequencies;
-      csv_parser<route> routes;
-      csv_parser<shape> shapes;
-      csv_parser<stop> stops;
-      csv_parser<stop_time> stop_times;
-      csv_parser<transfer> transfers;
-      csv_parser<trip> trips;
+      csv_parser<agency> agency_parser;
+      csv_parser<calendar> calendar_parser;
+      csv_parser<calendar_date> calendar_date_parser;
+      csv_parser<fare_attribute> fare_attribute_parser;
+      csv_parser<fare_rule> fare_rule_parser;
+      csv_parser<feed_info> feed_info_parser;
+      csv_parser<frequency> frequency_parser;
+      csv_parser<route> route_parser;
+      csv_parser<shape> shape_parser;
+      csv_parser<stop> stop_parser;
+      csv_parser<stop_time> stop_time_parser;
+      csv_parser<transfer> transfer_parser;
+      csv_parser<trip> trip_parser;
 
 
       source(std::string directory) : directory(directory) {
-        agency          = { directory + "/agency.txt",          agency_fields };
-        calendar        = { directory + "/calendar.txt",        calendar_fields };
-        calendar_dates  = { directory + "/calendar_dates.txt",  calendar_date_fields };
-        fare_attributes = { directory + "/fare_attributes.txt", fare_attribute_fields };
-        fare_rules      = { directory + "/fare_rules.txt",      fare_rule_fields };
-        feed_info       = { directory + "/feed_info.txt",       feed_info_fields };
-        frequencies     = { directory + "/frequencies.txt",     frequency_fields };
-        routes          = { directory + "/routes.txt",          route_fields };
-        shapes          = { directory + "/shapes.txt",          shape_fields };
-        stops           = { directory + "/stops.txt",           stop_fields };
-        stop_times      = { directory + "/stop_times.txt",      stop_time_fields };
-        transfers       = { directory + "/transfers.txt",       transfer_fields };
-        trips           = { directory + "/trips.txt",           trip_fields };
+        agency_parser         = { directory + "/agency.txt",          agency_fields };
+        calendar_parser       = { directory + "/calendar.txt",        calendar_fields };
+        calendar_date_parser  = { directory + "/calendar_dates.txt",  calendar_date_fields };
+        fare_attribute_parser = { directory + "/fare_attributes.txt", fare_attribute_fields };
+        fare_rule_parser      = { directory + "/fare_rules.txt",      fare_rule_fields };
+        feed_info_parser      = { directory + "/feed_info.txt",       feed_info_fields };
+        frequency_parser      = { directory + "/frequencies.txt",     frequency_fields };
+        route_parser          = { directory + "/routes.txt",          route_fields };
+        shape_parser          = { directory + "/shapes.txt",          shape_fields };
+        stop_parser           = { directory + "/stops.txt",           stop_fields };
+        stop_time_parser      = { directory + "/stop_times.txt",      stop_time_fields };
+        transfer_parser       = { directory + "/transfers.txt",       transfer_fields };
+        trip_parser           = { directory + "/trips.txt",           trip_fields };
       };
   };
 }

--- a/include/gtfs/source.h
+++ b/include/gtfs/source.h
@@ -1,0 +1,183 @@
+#pragma once
+
+#include "gtfs/field_mapper.h"
+#include "gtfs/csv_parser.h"
+
+namespace gtfs {
+  class source {
+    // The path to the directory containing GTFS archive files. All file names
+    // are expected to be the snake-cased plural of the object type followed by
+    // `.txt` (e.g., `stop_times.txt`, `routes.txt`), with the exception of
+    // `agency.txt`, `calendar.txt`, and `feed_info.txt`.
+    std::string directory;
+
+    template<typename T>
+    using field_map_t = std::map<std::string, field_mapper<T>>;
+
+    public:
+      // Field maps for each type defined by GTFS.
+      field_map_t<agency> agency_fields = {
+        { "agency_id",        make_field_mapper(&agency::id)       },
+        { "agency_name",      make_field_mapper(&agency::name)     },
+        { "agency_url",       make_field_mapper(&agency::url)      },
+        { "agency_timezone",  make_field_mapper(&agency::timezone) },
+        { "agency_lang",      make_field_mapper(&agency::language) },
+        { "agency_phone",     make_field_mapper(&agency::phone)    },
+        { "agency_fare_url",  make_field_mapper(&agency::fare_url) },
+        { "agency_email",     make_field_mapper(&agency::email)    }
+      };
+
+      field_map_t<calendar> calendar_fields = {
+        { "service_id",  make_field_mapper(&calendar::service_id)  },
+        { "monday",      make_field_mapper(&calendar::monday)      },
+        { "tuesday",     make_field_mapper(&calendar::tuesday)     },
+        { "wednesday",   make_field_mapper(&calendar::wednesday)   },
+        { "thursday",    make_field_mapper(&calendar::thursday)    },
+        { "friday",      make_field_mapper(&calendar::friday)      },
+        { "saturday",    make_field_mapper(&calendar::saturday)    },
+        { "sunday",      make_field_mapper(&calendar::sunday)      },
+        { "start_date",  make_field_mapper(&calendar::start_date)  },
+        { "end_date",    make_field_mapper(&calendar::end_date)    }
+      };
+
+      field_map_t<calendar_date> calendar_date_fields = {
+        { "service_id",     make_field_mapper(&calendar_date::service_id)     },
+        { "date",           make_field_mapper(&calendar_date::date)           },
+        { "exception_type", make_field_mapper(&calendar_date::exception_type) }
+      };
+
+      field_map_t<fare_attribute> fare_attribute_fields = {
+        { "fare_id",           make_field_mapper(&fare_attribute::fare_id)           },
+        { "price",             make_field_mapper(&fare_attribute::price)             },
+        { "currency_type",     make_field_mapper(&fare_attribute::currency_type)     },
+        { "payment_method",    make_field_mapper(&fare_attribute::payment_method)    },
+        { "transfers",         make_field_mapper(&fare_attribute::transfers)         },
+        { "transfer_duration", make_field_mapper(&fare_attribute::transfer_duration) },
+      };
+
+      field_map_t<fare_rule> fare_rule_fields = {
+        { "fare_id",         make_field_mapper(&fare_rule::fare_id)        },
+        { "route_id",        make_field_mapper(&fare_rule::route_id)       },
+        { "origin_id",       make_field_mapper(&fare_rule::origin_id)      },
+        { "destination_id",  make_field_mapper(&fare_rule::destination_id) },
+        { "contains_id",     make_field_mapper(&fare_rule::contains_id)    }
+      };
+
+      field_map_t<feed_info> feed_info_fields = {
+        { "feed_publisher_name", make_field_mapper(&feed_info::publisher_name) },
+        { "feed_publisher_url",  make_field_mapper(&feed_info::publisher_url)  },
+        { "feed_lang",           make_field_mapper(&feed_info::language)       },
+        { "feed_start_date",     make_field_mapper(&feed_info::start_date)     },
+        { "feed_end_date",       make_field_mapper(&feed_info::end_date)       },
+        { "feed_version",        make_field_mapper(&feed_info::version)        }
+      };
+
+      field_map_t<frequency> frequency_fields = {
+        { "trip_id",       make_field_mapper(&frequency::trip_id)     },
+        { "start_time",    make_field_mapper(&frequency::start_time)  },
+        { "end_time",      make_field_mapper(&frequency::end_time)    },
+        { "headway_secs",  make_field_mapper(&frequency::headway)     },
+        { "exact_times",   make_field_mapper(&frequency::exact_times) }
+      };
+
+      field_map_t<route> route_fields = {
+        { "route_id",         make_field_mapper(&route::id)           },
+        { "agency_id",        make_field_mapper(&route::agency_id)    },
+        { "route_short_name", make_field_mapper(&route::short_name)   },
+        { "route_long_name",  make_field_mapper(&route::long_name)    },
+        { "route_desc",       make_field_mapper(&route::description)  },
+        { "route_url",        make_field_mapper(&route::url)          },
+        { "route_type",       make_field_mapper(&route::type)         },
+        { "route_color",      make_field_mapper(&route::color)        },
+        { "route_text_color", make_field_mapper(&route::text_color)   }
+      };
+
+      field_map_t<shape> shape_fields = {
+        { "shape_id",            make_field_mapper(&shape::id)         },
+        { "shape_pt_lat",        make_field_mapper(&shape::latitude)   },
+        { "shape_pt_lon",        make_field_mapper(&shape::longitude)  },
+        { "shape_pt_sequence",   make_field_mapper(&shape::index)      },
+        { "shape_dist_traveled", make_field_mapper(&shape::distance)   }
+      };
+
+      field_map_t<stop> stop_fields = {
+        { "stop_id",             make_field_mapper(&stop::id)                  },
+        { "stop_code",           make_field_mapper(&stop::code)                },
+        { "stop_name",           make_field_mapper(&stop::name)                },
+        { "stop_desc",           make_field_mapper(&stop::description)         },
+        { "stop_lat",            make_field_mapper(&stop::latitude)            },
+        { "stop_lon",            make_field_mapper(&stop::longitude)           },
+        { "zone_id",             make_field_mapper(&stop::zone_id)             },
+        { "stop_url",            make_field_mapper(&stop::stop_url)            },
+        { "location_type",       make_field_mapper(&stop::type)                },
+        { "parent_station",      make_field_mapper(&stop::parent_id)           },
+        { "stop_timezone",       make_field_mapper(&stop::timezone)            },
+        { "wheelchair_boarding", make_field_mapper(&stop::wheelchair_boarding) }
+      };
+
+      field_map_t<stop_time> stop_time_fields = {
+        { "trip_id",             make_field_mapper(&stop_time::trip_id)        },
+        { "arrival_time",        make_field_mapper(&stop_time::arrival_time)   },
+        { "departure_time",      make_field_mapper(&stop_time::departure_time) },
+        { "stop_id",             make_field_mapper(&stop_time::stop_id)        },
+        { "stop_sequence",       make_field_mapper(&stop_time::index)          },
+        { "stop_headsign",       make_field_mapper(&stop_time::headsign)       },
+        { "pickup_type",         make_field_mapper(&stop_time::pickup_type)    },
+        { "drop_off_type",       make_field_mapper(&stop_time::dropoff_type)   },
+        { "shape_dist_traveled", make_field_mapper(&stop_time::distance)       },
+        { "timepoint",           make_field_mapper(&stop_time::timepoint)      }
+      };
+
+      field_map_t<transfer> transfer_fields = {
+        { "from_stop_id",      make_field_mapper(&transfer::from_stop_id)       },
+        { "to_stop_id",        make_field_mapper(&transfer::to_stop_id)         },
+        { "transfer_type",     make_field_mapper(&transfer::transfer_type)      },
+        { "min_transfer_time", make_field_mapper(&transfer::min_transfer_time)  }
+      };
+
+      field_map_t<trip> trip_fields {
+        { "route_id",              make_field_mapper(&trip::route_id)              },
+        { "service_id",            make_field_mapper(&trip::service_id)            },
+        { "trip_id",               make_field_mapper(&trip::id)                    },
+        { "trip_headsign",         make_field_mapper(&trip::headsign)              },
+        { "trip_short_name",       make_field_mapper(&trip::short_name)            },
+        { "direction_id",          make_field_mapper(&trip::direction_id)          },
+        { "block_id",              make_field_mapper(&trip::block_id)              },
+        { "shape_id",              make_field_mapper(&trip::shape_id)              },
+        { "wheelchair_accessible", make_field_mapper(&trip::wheelchair_accessible) },
+        { "bikes_allowed",         make_field_mapper(&trip::bikes_allowed)         }
+      };
+
+      // Parser objects for each type defined by GTFS.
+      csv_parser<agency> agency;
+      csv_parser<calendar> calendar;
+      csv_parser<calendar_date> calendar_dates;
+      csv_parser<fare_attribute> fare_attributes;
+      csv_parser<fare_rule> fare_rules;
+      csv_parser<feed_info> feed_info;
+      csv_parser<frequency> frequencies;
+      csv_parser<route> routes;
+      csv_parser<shape> shapes;
+      csv_parser<stop> stops;
+      csv_parser<stop_time> stop_times;
+      csv_parser<transfer> transfers;
+      csv_parser<trip> trips;
+
+
+      source(std::string directory) : directory(directory) {
+        agency          = { directory + "/agency.txt",          agency_fields };
+        calendar        = { directory + "/calendar.txt",        calendar_fields };
+        calendar_dates  = { directory + "/calendar_dates.txt",  calendar_date_fields };
+        fare_attributes = { directory + "/fare_attributes.txt", fare_attribute_fields };
+        fare_rules      = { directory + "/fare_rules.txt",      fare_rule_fields };
+        feed_info       = { directory + "/feed_info.txt",       feed_info_fields };
+        frequencies     = { directory + "/frequencies.txt",     frequency_fields };
+        routes          = { directory + "/routes.txt",          route_fields };
+        shapes          = { directory + "/shapes.txt",          shape_fields };
+        stops           = { directory + "/stops.txt",           stop_fields };
+        stop_times      = { directory + "/stop_times.txt",      stop_time_fields };
+        transfers       = { directory + "/transfers.txt",       transfer_fields };
+        trips           = { directory + "/trips.txt",           trip_fields };
+      };
+  };
+}

--- a/include/gtfs/stop.h
+++ b/include/gtfs/stop.h
@@ -2,15 +2,10 @@
 
 #include <ostream>
 
-#include "gtfs/csv_parser.h"
-
 
 namespace gtfs {
   class stop {
     public:
-      static csv_parser<stop> parser;
-      static std::string file_name;
-
       // Unique identifier for the stop
       std::string id;
       // Code used on signs and displays to represent this stop
@@ -49,20 +44,4 @@ namespace gtfs {
           << "\tType: " << s.type << "\n";
       };
   };
-
-  std::string stop::file_name = "stops.txt";
-  csv_parser<stop> stop::parser = {{
-    { "stop_id",             make_field_mapper(&stop::id)                  },
-    { "stop_code",           make_field_mapper(&stop::code)                },
-    { "stop_name",           make_field_mapper(&stop::name)                },
-    { "stop_desc",           make_field_mapper(&stop::description)         },
-    { "stop_lat",            make_field_mapper(&stop::latitude)            },
-    { "stop_lon",            make_field_mapper(&stop::longitude)           },
-    { "zone_id",             make_field_mapper(&stop::zone_id)             },
-    { "stop_url",            make_field_mapper(&stop::stop_url)            },
-    { "location_type",       make_field_mapper(&stop::type)                },
-    { "parent_station",      make_field_mapper(&stop::parent_id)           },
-    { "stop_timezone",       make_field_mapper(&stop::timezone)            },
-    { "wheelchair_boarding", make_field_mapper(&stop::wheelchair_boarding) }
-  }};
 }

--- a/include/gtfs/stop_time.h
+++ b/include/gtfs/stop_time.h
@@ -2,15 +2,10 @@
 
 #include <ostream>
 
-#include "gtfs/csv_parser.h"
-
 
 namespace gtfs {
   class stop_time {
     public:
-      static csv_parser<stop_time> parser;
-      static std::string file_name;
-
       // Identifier for the trip containing this stop time
       std::string trip_id;
       // Time at which the vehicle should arrive at this stop
@@ -49,18 +44,4 @@ namespace gtfs {
           << "\tTimepoint: " << st.timepoint << "\n";
       };
   };
-
-  std::string stop_time::file_name = "stop_times.txt";
-  csv_parser<stop_time> stop_time::parser = {{
-    { "trip_id",             make_field_mapper(&stop_time::trip_id)        },
-    { "arrival_time",        make_field_mapper(&stop_time::arrival_time)   },
-    { "departure_time",      make_field_mapper(&stop_time::departure_time) },
-    { "stop_id",             make_field_mapper(&stop_time::stop_id)        },
-    { "stop_sequence",       make_field_mapper(&stop_time::index)          },
-    { "stop_headsign",       make_field_mapper(&stop_time::headsign)       },
-    { "pickup_type",         make_field_mapper(&stop_time::pickup_type)    },
-    { "drop_off_type",       make_field_mapper(&stop_time::dropoff_type)   },
-    { "shape_dist_traveled", make_field_mapper(&stop_time::distance)       },
-    { "timepoint",           make_field_mapper(&stop_time::timepoint)      }
-  }};
 }

--- a/include/gtfs/transfer.h
+++ b/include/gtfs/transfer.h
@@ -2,15 +2,10 @@
 
 #include <ostream>
 
-#include "gtfs/csv_parser.h"
-
 
 namespace gtfs {
   class transfer {
     public:
-      static csv_parser<transfer> parser;
-      static std::string file_name;
-
       // Stop from which this transfer applies
       std::string from_stop_id;
       // Stop to which this transfer applies
@@ -32,12 +27,4 @@ namespace gtfs {
           << "\tMinimum Transfer Time: " << t.min_transfer_time << "\n";
       };
   };
-
-  std::string transfer::file_name = "transfers.txt";
-  csv_parser<transfer> transfer::parser = {{
-    { "from_stop_id",      make_field_mapper(&transfer::from_stop_id)       },
-    { "to_stop_id",        make_field_mapper(&transfer::to_stop_id)         },
-    { "transfer_type",     make_field_mapper(&transfer::transfer_type)      },
-    { "min_transfer_time", make_field_mapper(&transfer::min_transfer_time)  }
-  }};
 }

--- a/include/gtfs/trip.h
+++ b/include/gtfs/trip.h
@@ -2,15 +2,10 @@
 
 #include <ostream>
 
-#include "gtfs/csv_parser.h"
-
 
 namespace gtfs {
   class trip {
     public:
-      static csv_parser<trip> parser;
-      static std::string file_name;
-
       // Identifier of the route traveled by this trip
       std::string route_id;
       // Identifier of the service containing this trip
@@ -50,18 +45,4 @@ namespace gtfs {
           << "\tBikes Allowed: " << t.bikes_allowed << "\n";
       };
   };
-
-  std::string trip::file_name = "trips.txt";
-  csv_parser<trip> trip::parser = {{
-    { "route_id",              make_field_mapper(&trip::route_id)              },
-    { "service_id",            make_field_mapper(&trip::service_id)            },
-    { "trip_id",               make_field_mapper(&trip::id)                    },
-    { "trip_headsign",         make_field_mapper(&trip::headsign)              },
-    { "trip_short_name",       make_field_mapper(&trip::short_name)            },
-    { "direction_id",          make_field_mapper(&trip::direction_id)          },
-    { "block_id",              make_field_mapper(&trip::block_id)              },
-    { "shape_id",              make_field_mapper(&trip::shape_id)              },
-    { "wheelchair_accessible", make_field_mapper(&trip::wheelchair_accessible) },
-    { "bikes_allowed",         make_field_mapper(&trip::bikes_allowed)         }
-  }};
 }

--- a/include/timetable/calendar.h
+++ b/include/timetable/calendar.h
@@ -10,11 +10,10 @@ namespace Timetable {
     using calendar_t = std::unordered_map<std::string, std::unordered_map<std::string, bool>>;
 
     public:
-      std::string archive_dir;
       calendar_t calendar;
 
-      Calendar(std::string directory) : archive_dir(directory) {
-        for(auto cd : gtfs::calendar_date::parser.all(archive_dir)) {
+      Calendar(gtfs::source& source) {
+        for(auto cd : source.calendar_dates.all()) {
           calendar[cd.service_id][cd.date] = (cd.exception_type == 1);
         }
       };

--- a/include/timetable/calendar.h
+++ b/include/timetable/calendar.h
@@ -13,7 +13,7 @@ namespace Timetable {
       calendar_t calendar;
 
       Calendar(gtfs::source& source) {
-        for(auto cd : source.calendar_dates.all()) {
+        for(auto cd : source.calendar_date_parser.all()) {
           calendar[cd.service_id][cd.date] = (cd.exception_type == 1);
         }
       };

--- a/include/visit.h
+++ b/include/visit.h
@@ -19,9 +19,9 @@ class Visit {
 
     Visit(gtfs::stop_time& st, std::string arrival_date, std::string departure_date, Timetable::Timetable& tt) :
         stop_time(st),
-        station(tt.stop_map[stop_time.stop_id]),
-        trip(tt.trip_map[stop_time.trip_id]),
-        route(tt.route_map[trip.route_id]) {
+        station(tt.stops[stop_time.stop_id]),
+        trip(tt.trips[stop_time.trip_id]),
+        route(tt.routes[trip.route_id]) {
       arrival   = { arrival_date,   stop_time.arrival_time    };
       departure = { departure_date, stop_time.departure_time  };
     };

--- a/src/timetable.cc
+++ b/src/timetable.cc
@@ -55,14 +55,14 @@ MsgPack visits_between(std::string stop, std::string start, std::string end, int
 
 
 int main() {
-  Transport t("ws://shark-nyc1.transio.us:8080/ws");
+  // Transport t("ws://shark-nyc1.transio.us:8080/ws");
 
-  t.procedure("timetable.visits_between",             visits_between);
+  // t.procedure("timetable.visits_between",             visits_between);
   // t.procedure("timetable.visits_between_from_route",  visits_between_from_route);
-  t.start();
+  // t.start();
 
-  // visits_between("BUS389", "20170130 06:44:00", "20170130 10:44:00", 2);
-  // visits_between("BUS389", "20170130 06:44:00", "20170130 10:44:00", 10);
+  visits_between("BUS389", "20170130 06:44:00", "20170130 10:44:00", 2);
+  visits_between("BUS389", "20170130 06:44:00", "20170130 10:44:00", 10);
 
   return 0;
 }

--- a/src/timetable.cc
+++ b/src/timetable.cc
@@ -19,7 +19,7 @@ MsgPack make_payload(std::vector<Visit> visits) {
 }
 
 MsgPack do_visits_between(std::string stop_code, DateTime start, DateTime end, int count) {
-  auto stop       = tt.stop_map[stop_code];
+  auto stop       = tt.stops[stop_code];
   auto start_time = start.time;
   auto end_time   = end.time;
 


### PR DESCRIPTION
The `gtfs::source` class is responsible for all parsing of gtfs archives. This means that the model classes no longer contain mapping information or anything other than their instance properties (no `static` properties), making them more semantic and flexible, as well as centralizing all parsing logic to one area, rather than distributing it across many files.