### PR TITLE
Distributed RPC definitions

### DIFF
--- a/include/timetable.h
+++ b/include/timetable.h
@@ -1,6 +1,28 @@
 #pragma once
 
+#include "datetime.h"
+#include "gtfs.h"
 #include "timetable/visit_list.h"
 #include "timetable/bounds.h"
 #include "timetable/calendar.h"
 #include "timetable/timetable.h"
+#include "visit.h"
+
+
+extern Timetable::Timetable tt;
+
+
+MsgPack make_payload(std::vector<Visit> visits);
+
+////
+// RPC definitions
+////
+MsgPack visits_before (std::string stop_code, std::string end, int count);
+MsgPack visits_between(std::string stop_code, std::string start, std::string end, int count);
+MsgPack visits_after  (std::string stop_code, std::string start, int count);
+
+// These are temporary implementations until the WAMP client supports optional
+// parameters in RPCs.
+MsgPack visits_before_from_route  (std::string stop_code, std::string end, std::string route, int count);
+MsgPack visits_between_from_route (std::string stop_code, std::string start, std::string end, std::string route, int count);
+MsgPack visits_after_from_route   (std::string stop_code, std::string start, std::string route, int count);

--- a/include/timetable/bounds.h
+++ b/include/timetable/bounds.h
@@ -19,11 +19,8 @@ namespace Timetable {
   using bounds_t          = bounds_template<visit_list::const_iterator>;
   using reverse_bounds_t  = bounds_template<visit_list::const_reverse_iterator>;
 
-  reverse_bounds_t reverse(bounds_t bounds) {
+  template<typename BoundsType>
+  reverse_bounds_t reverse(BoundsType bounds) {
     return { std::make_reverse_iterator(bounds.end()), std::make_reverse_iterator(bounds.begin()) };
-  };
-
-  bounds_t reverse(reverse_bounds_t bounds) {
-    return { bounds.end().base(), bounds.begin().base() };
   };
 }

--- a/include/timetable/timetable.h
+++ b/include/timetable/timetable.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iostream>
 #include <map>
 #include <unordered_map>
 
@@ -56,10 +57,9 @@ namespace Timetable {
       ////
 
       reverse_bounds_t visits_before(const visit_list_key key) const {
-        auto lower_bound = visits.lower_bound(key.station_lower_bound());
         auto upper_bound = visits.upper_bound(key);
-        bounds_t bounds{ lower_bound, upper_bound };
-        return reverse(bounds);
+        auto lower_bound = visits.lower_bound(key.station_lower_bound());
+        return reverse(bounds_t{ lower_bound, upper_bound });
       };
 
       bounds_t visits_between(const visit_list_key key1, const visit_list_key key2) const {

--- a/src/make_payload.cc
+++ b/src/make_payload.cc
@@ -1,0 +1,8 @@
+#include "timetable.h"
+
+MsgPack make_payload(std::vector<Visit> visits) {
+  MsgPack payload;
+  payload.pack_array(visits.size());
+  for(auto v : visits) { payload.pack(v); }
+  return payload;
+}

--- a/src/rpcs/visits_after.cc
+++ b/src/rpcs/visits_after.cc
@@ -1,13 +1,12 @@
 #include "timetable.h"
 
 
-MsgPack do_visits_between(std::string stop_code, DateTime start, DateTime end, int count) {
+MsgPack do_visits_after(std::string stop_code, DateTime start, int count) {
   auto stop       = tt.stops[stop_code];
   auto start_time = start.time;
-  auto end_time   = end.time;
 
   std::vector<Visit> results;
-  for(auto pair : tt.visits_between({stop.id, start_time, "", ""}, {stop.id, end_time, "", ""})) {
+  for(auto pair : tt.visits_after({stop.id, start_time, "", ""})) {
     auto visit = pair.second;
     if(!tt.is_active(visit, start.date)) continue;
 
@@ -19,15 +18,14 @@ MsgPack do_visits_between(std::string stop_code, DateTime start, DateTime end, i
 }
 
 
-MsgPack visits_between(std::string stop, std::string start, std::string end, int count) {
-  std::cout << "Received call to `visits_between`: \n"
+MsgPack visits_after(std::string stop, std::string start, int count) {
+  std::cout << "Received call to `visits_after`: \n"
             << "\tstop:   " << stop << "\n"
             << "\tstart:  " << start << "\n"
-            << "\tend:    " << end << "\n"
             << "\tcount:  " << count << "\n";
 
   auto response_start  = std::chrono::system_clock::now();
-  MsgPack result = do_visits_between(stop, start, end, count);
+  MsgPack result = do_visits_after(stop, start, count);
   auto response_end    = std::chrono::system_clock::now();
   std::chrono::duration<double, std::milli> elapsed_time = response_end - response_start;
 
@@ -36,3 +34,4 @@ MsgPack visits_between(std::string stop, std::string start, std::string end, int
 
   return result;
 }
+

--- a/src/rpcs/visits_after_from_route.cc
+++ b/src/rpcs/visits_after_from_route.cc
@@ -1,15 +1,17 @@
 #include "timetable.h"
 
 
-MsgPack do_visits_between(std::string stop_code, DateTime start, DateTime end, int count) {
+MsgPack do_visits_after_from_route(std::string stop_code, DateTime start, std::string route_name, int count) {
   auto stop       = tt.stops[stop_code];
   auto start_time = start.time;
-  auto end_time   = end.time;
+  auto route      = tt.routes_by_short_name[route_name];
 
   std::vector<Visit> results;
-  for(auto pair : tt.visits_between({stop.id, start_time, "", ""}, {stop.id, end_time, "", ""})) {
+  for(auto pair : tt.visits_after({stop.id, start_time, "", ""})) {
     auto visit = pair.second;
+    auto visit_route = tt.routes[tt.trips[visit.trip_id].route_id];
     if(!tt.is_active(visit, start.date)) continue;
+    if(visit_route.id != route.id) continue;
 
     results.push_back({visit, start.date, start.date, tt});
     if((int) results.size() >= count) break;
@@ -19,15 +21,15 @@ MsgPack do_visits_between(std::string stop_code, DateTime start, DateTime end, i
 }
 
 
-MsgPack visits_between(std::string stop, std::string start, std::string end, int count) {
-  std::cout << "Received call to `visits_between`: \n"
+MsgPack visits_after_from_route(std::string stop, std::string start, std::string route_name, int count) {
+  std::cout << "Received call to `visits_after_from_route`: \n"
             << "\tstop:   " << stop << "\n"
             << "\tstart:  " << start << "\n"
-            << "\tend:    " << end << "\n"
+            << "\troute:  " << route_name << "\n"
             << "\tcount:  " << count << "\n";
 
   auto response_start  = std::chrono::system_clock::now();
-  MsgPack result = do_visits_between(stop, start, end, count);
+  MsgPack result = do_visits_after_from_route(stop, start, route_name, count);
   auto response_end    = std::chrono::system_clock::now();
   std::chrono::duration<double, std::milli> elapsed_time = response_end - response_start;
 
@@ -36,3 +38,4 @@ MsgPack visits_between(std::string stop, std::string start, std::string end, int
 
   return result;
 }
+

--- a/src/rpcs/visits_before.cc
+++ b/src/rpcs/visits_before.cc
@@ -1,0 +1,36 @@
+#include "timetable.h"
+
+
+MsgPack do_visits_before(std::string stop_code, DateTime end, int count) {
+  auto stop     = tt.stops[stop_code];
+  auto end_time = end.time;
+
+  std::vector<Visit> results;
+  for(auto pair : tt.visits_before({stop.id, end_time, "", ""})) {
+    auto visit = pair.second;
+    if(!tt.is_active(visit, end.date)) continue;
+
+    results.push_back({visit, end.date, end.date, tt});
+    if((int) results.size() >= count) break;
+  }
+
+  return make_payload(results);
+}
+
+
+MsgPack visits_before(std::string stop, std::string end, int count) {
+  std::cout << "Received call to `visits_before`: \n"
+            << "\tstop:   " << stop << "\n"
+            << "\tend:    " << end << "\n"
+            << "\tcount:  " << count << "\n";
+
+  auto response_start  = std::chrono::system_clock::now();
+  MsgPack result = do_visits_before(stop, end, count);
+  auto response_end    = std::chrono::system_clock::now();
+  std::chrono::duration<double, std::milli> elapsed_time = response_end - response_start;
+
+  std::cout << "Responded in " << elapsed_time.count() << "ms with:\n"
+            << result << "\n\n";
+
+  return result;
+}

--- a/src/rpcs/visits_before_from_route.cc
+++ b/src/rpcs/visits_before_from_route.cc
@@ -1,0 +1,41 @@
+#include "timetable.h"
+
+
+MsgPack do_visits_before_from_route(std::string stop_code, DateTime end, std::string route_name, int count) {
+  auto stop     = tt.stops[stop_code];
+  auto end_time = end.time;
+  auto route    = tt.routes_by_short_name[route_name];
+
+  std::vector<Visit> results;
+  for(auto pair : tt.visits_before({stop.id, end_time, route.id, ""})) {
+    auto visit = pair.second;
+    auto visit_route = tt.routes[tt.trips[visit.trip_id].route_id];
+    if(!tt.is_active(visit, end.date)) continue;
+    if(visit_route.id != route.id) continue;
+
+    results.push_back({visit, end.date, end.date, tt});
+    if((int) results.size() >= count) break;
+  }
+
+  return make_payload(results);
+}
+
+
+MsgPack visits_before_from_route(std::string stop, std::string end, std::string route_name, int count) {
+  std::cout << "Received call to `visits_before_from_route`: \n"
+            << "\tstop:   " << stop << "\n"
+            << "\tend:    " << end << "\n"
+            << "\troute:  " << route_name << "\n"
+            << "\tcount:  " << count << "\n";
+
+  auto response_start  = std::chrono::system_clock::now();
+  MsgPack result = do_visits_before_from_route(stop, end, route_name, count);
+  auto response_end    = std::chrono::system_clock::now();
+  std::chrono::duration<double, std::milli> elapsed_time = response_end - response_start;
+
+  std::cout << "Responded in " << elapsed_time.count() << "ms with:\n"
+            << result << "\n\n";
+
+  return result;
+}
+

--- a/src/rpcs/visits_between.cc
+++ b/src/rpcs/visits_between.cc
@@ -1,0 +1,37 @@
+#include "timetable.h"
+
+
+MsgPack do_visits_between(std::string stop_code, DateTime start, DateTime end, int count) {
+  auto stop       = tt.stops[stop_code];
+  auto start_time = start.time;
+  auto end_time   = end.time;
+
+  std::vector<Visit> results;
+  for(auto pair : tt.visits_between({stop.id, start_time, "", ""}, {stop.id, end_time, "", ""})) {
+    auto visit = pair.second;
+    if(!tt.is_active(visit, start.date)) continue;
+
+    results.push_back({visit, start.date, start.date, tt});
+    if(results.size() >= count) break;
+  }
+
+  return make_payload(results);
+}
+
+MsgPack visits_between(std::string stop, std::string start, std::string end, int count) {
+  std::cout << "Received call to `visits_between`: \n"
+            << "\tstop:   " << stop << "\n"
+            << "\tstart:  " << start << "\n"
+            << "\tend:    " << end << "\n"
+            << "\tcount:  " << count << "\n";
+
+  auto response_start  = std::chrono::system_clock::now();
+  MsgPack result = do_visits_between(stop, start, end, count);
+  auto response_end    = std::chrono::system_clock::now();
+  std::chrono::duration<double, std::milli> elapsed_time = response_end - response_start;
+
+  std::cout << "Responded in " << elapsed_time.count() << "ms with:\n"
+            << result << "\n\n";
+
+  return result;
+}

--- a/src/rpcs/visits_between_from_route.cc
+++ b/src/rpcs/visits_between_from_route.cc
@@ -1,15 +1,18 @@
 #include "timetable.h"
 
 
-MsgPack do_visits_between(std::string stop_code, DateTime start, DateTime end, int count) {
+MsgPack do_visits_between_from_route(std::string stop_code, DateTime start, DateTime end, std::string route_name, int count) {
   auto stop       = tt.stops[stop_code];
   auto start_time = start.time;
   auto end_time   = end.time;
+  auto route      = tt.routes_by_short_name[route_name];
 
   std::vector<Visit> results;
-  for(auto pair : tt.visits_between({stop.id, start_time, "", ""}, {stop.id, end_time, "", ""})) {
+  for(auto pair : tt.visits_between({stop.id, start_time, route.id, ""}, {stop.id, end_time, route.id, ""})) {
     auto visit = pair.second;
+    auto visit_route = tt.routes[tt.trips[visit.trip_id].route_id];
     if(!tt.is_active(visit, start.date)) continue;
+    if(visit_route.id != route.id) continue;
 
     results.push_back({visit, start.date, start.date, tt});
     if((int) results.size() >= count) break;
@@ -19,15 +22,16 @@ MsgPack do_visits_between(std::string stop_code, DateTime start, DateTime end, i
 }
 
 
-MsgPack visits_between(std::string stop, std::string start, std::string end, int count) {
-  std::cout << "Received call to `visits_between`: \n"
+MsgPack visits_between_from_route(std::string stop, std::string start, std::string end, std::string route_name, int count) {
+  std::cout << "Received call to `visits_between_from_route`: \n"
             << "\tstop:   " << stop << "\n"
             << "\tstart:  " << start << "\n"
             << "\tend:    " << end << "\n"
+            << "\troute:  " << route_name << "\n"
             << "\tcount:  " << count << "\n";
 
   auto response_start  = std::chrono::system_clock::now();
-  MsgPack result = do_visits_between(stop, start, end, count);
+  MsgPack result = do_visits_between_from_route(stop, start, end, route_name, count);
   auto response_end    = std::chrono::system_clock::now();
   std::chrono::duration<double, std::milli> elapsed_time = response_end - response_start;
 
@@ -36,3 +40,4 @@ MsgPack visits_between(std::string stop, std::string start, std::string end, int
 
   return result;
 }
+

--- a/src/timetable.cc
+++ b/src/timetable.cc
@@ -10,14 +10,14 @@ Timetable::Timetable tt("data/citybus");
 
 
 int main() {
-  // Transport t("ws://shark-nyc1.transio.us:8080/ws");
+  Transport t("ws://shark-nyc1.transio.us:8080/ws");
 
-  // t.procedure("timetable.visits_between",             visits_between);
-  // t.procedure("timetable.visits_between_from_route",  visits_between_from_route);
-  // t.start();
+  t.procedure("timetable.visits_between",             visits_between);
+  t.procedure("timetable.visits_between_from_route",  visits_between_from_route);
+  t.start();
 
-  visits_between("BUS389", "20170130 06:44:00", "20170130 10:44:00", 2);
-  visits_between("BUS389", "20170130 06:44:00", "20170130 10:44:00", 10);
+  // visits_between("BUS389", "20170130 06:44:00", "20170130 10:44:00", 2);
+  // visits_between("BUS389", "20170130 06:44:00", "20170130 10:44:00", 10);
 
   return 0;
 }

--- a/src/timetable.cc
+++ b/src/timetable.cc
@@ -2,56 +2,11 @@
 #include <sstream>
 #include <vector>
 
-#include "datetime.h"
-#include "gtfs.h"
 #include "timetable.h"
 #include "transport.h"
-#include "visit.h"
 
 
 Timetable::Timetable tt("data/citybus");
-
-MsgPack make_payload(std::vector<Visit> visits) {
-  MsgPack payload;
-  payload.pack_array(visits.size());
-  for(auto v : visits) { payload.pack(v); }
-  return payload;
-}
-
-MsgPack do_visits_between(std::string stop_code, DateTime start, DateTime end, int count) {
-  auto stop       = tt.stops[stop_code];
-  auto start_time = start.time;
-  auto end_time   = end.time;
-
-  std::vector<Visit> results;
-  for(auto pair : tt.visits_between({stop.id, start_time, "", ""}, {stop.id, end_time, "", ""})) {
-    auto visit = pair.second;
-    if(!tt.is_active(visit, start.date)) continue;
-
-    results.push_back({visit, start.date, start.date, tt});
-    if(results.size() >= count) break;
-  }
-
-  return make_payload(results);
-}
-
-MsgPack visits_between(std::string stop, std::string start, std::string end, int count) {
-  std::cout << "Received call to `visits_between`: \n"
-            << "\tstop:   " << stop << "\n"
-            << "\tstart:  " << start << "\n"
-            << "\tend:    " << end << "\n"
-            << "\tcount:  " << count << "\n";
-
-  auto response_start  = std::chrono::system_clock::now();
-  MsgPack result = do_visits_between(stop, start, end, count);
-  auto response_end    = std::chrono::system_clock::now();
-  std::chrono::duration<double, std::milli> elapsed_time = response_end - response_start;
-
-  std::cout << "Responded in " << elapsed_time.count() << "ms with:\n"
-            << result << "\n\n";
-
-  return result;
-}
 
 
 int main() {


### PR DESCRIPTION
RPCs should exist in their own translation units as a way of separating concerns and additionally improving compile times (sans `make clean` escapades).

This PR also implements all of the RPCs conformant to and refined by #3 and #5 respectively.