### PR TITLE
Make timetable build on gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CXX ?= clang
 # Extension of source files used in the project
 SRC_EXT = cc
 # Path to the source directory, relative to the makefile
-SRC_PATH = src/
+SRC_PATH = src
 # Space-separated pkg-config libraries used by this project
 LIBS =
 # General compiler flags
@@ -218,3 +218,6 @@ $(BUILD_PATH)/%.o: $(SRC_PATH)/%.$(SRC_EXT)
 	$(CMD_PREFIX)$(CXX) $(CXXFLAGS) $(INCLUDES) -MP -MMD -c $< -o $@
 	@echo -en "\t Compile time: "
 	@$(END_TIME)
+
+print-%:
+	@echo '$*=$($*)'

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,3 @@ $(BUILD_PATH)/%.o: $(SRC_PATH)/%.$(SRC_EXT)
 	$(CMD_PREFIX)$(CXX) $(CXXFLAGS) $(INCLUDES) -MP -MMD -c $< -o $@
 	@echo -en "\t Compile time: "
 	@$(END_TIME)
-
-print-%:
-	@echo '$*=$($*)'

--- a/include/datetime.h
+++ b/include/datetime.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <ctime>
 #include <iostream>
 #include <ostream>
 #include <sstream>
+#include <tuple>
 
 
 class DateTime {

--- a/include/timetable/index.h
+++ b/include/timetable/index.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <map>
 
 #include "gtfs.h"

--- a/include/timetable/timetable.h
+++ b/include/timetable/timetable.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+#include <chrono>
 #include <iostream>
 #include <map>
 #include <unordered_map>

--- a/src/datetime/resolve.cc
+++ b/src/datetime/resolve.cc
@@ -8,19 +8,18 @@
 // ranges quic quickly becomes complex with varying-length months, leap years,
 // Daylight Savings Time, etc.
 void DateTime::resolve() {
-  std::tm t = {
-    // `tm_year` stores years since 1900. `years` is an absolute value.
-    .tm_year  = years - 1900,
-    // `tm_mon` starts at 0. `months` is a value in the range [1,12].
-    .tm_mon   = months - 1,
-    .tm_mday  = days,
-    .tm_hour  = hours,
-    .tm_min   = minutes,
-    .tm_sec   = seconds,
-    // Defaulting `isdst` to -1 forces `mktime` to determine whether DST is
-    // in effect for this datetime.
-    .tm_isdst = -1
-  };
+  std::tm t;
+  // `tm_year` stores years since 1900. `years` is an absolute value.
+  t.tm_year  = years - 1900;
+  // `tm_mon` starts at 0. `months` is a value in the range [1;12].
+  t.tm_mon   = months - 1;
+  t.tm_mday  = days;
+  t.tm_hour  = hours;
+  t.tm_min   = minutes;
+  t.tm_sec   = seconds;
+  // Defaulting `isdst` to -1 forces `mktime` to determine whether DST is
+  // in effect for this datetime.
+  t.tm_isdst = -1;
 
   std::mktime(&t);
 


### PR DESCRIPTION
Per #13, here's a PR to keep track of changes to timetable needed to build using gcc. For reference, I'm targeting `gcc-6.3.0`.