### PR TITLE
Support default values in field_mapper

### DIFF
--- a/include/gtfs/field_mapper.h
+++ b/include/gtfs/field_mapper.h
@@ -26,14 +26,10 @@ namespace gtfs {
     explicit field_mapper(int         Class::*member) : int_target(member),     type(tINT)    {};
     explicit field_mapper(double      Class::*member) : double_target(member),  type(tDOUBLE) {};
 
-    explicit field_mapper(bool Class::*member, bool default_val) :
-      bool_target(member), type(tBOOL), default_bool(default_val) {};
-    explicit field_mapper(std::string Class::*member, std::string default_val) :
-      string_target(member), type(tSTRING), default_string(default_val) {};
-    explicit field_mapper(int Class::*member, int default_val) :
-      int_target(member), type(tINT), default_int(default_val) {};
-    explicit field_mapper(double Class::*member, double default_val) :
-      double_target(member), type(tDOUBLE), default_double(default_val) {};
+    explicit field_mapper(bool        Class::*member, bool        default_val) : bool_target(member),   type(tBOOL),   default_bool(default_val)   {};
+    explicit field_mapper(std::string Class::*member, std::string default_val) : string_target(member), type(tSTRING), default_string(default_val) {};
+    explicit field_mapper(int         Class::*member, int         default_val) : int_target(member),    type(tINT),    default_int(default_val)    {};
+    explicit field_mapper(double      Class::*member, double      default_val) : double_target(member), type(tDOUBLE), default_double(default_val) {};
 
     inline void apply(Class& inst, optional<int> val) const    { inst.*int_target = val.value_or(*default_int); }
     inline void apply(Class& inst, optional<bool> val) const   { inst.*bool_target = val.value_or(*default_bool); }

--- a/include/gtfs/field_mapper.h
+++ b/include/gtfs/field_mapper.h
@@ -1,15 +1,24 @@
 #pragma once
 
 #include "gtfs/types.h"
+#include <experimental/optional>
 
 namespace gtfs {
   template<class Class>
   struct field_mapper {
+    template<class U>
+    using optional = std::experimental::optional<U>;
+
     bool        Class::*bool_target;
     std::string Class::*string_target;
     int         Class::*int_target;
     double      Class::*double_target;
     Type        type;
+
+    optional<bool>        default_bool;
+    optional<std::string> default_string;
+    optional<int>         default_int;
+    optional<double>      default_double;
 
     explicit field_mapper() = default;
     explicit field_mapper(bool        Class::*member) : bool_target(member),    type(tBOOL)   {};
@@ -17,14 +26,33 @@ namespace gtfs {
     explicit field_mapper(int         Class::*member) : int_target(member),     type(tINT)    {};
     explicit field_mapper(double      Class::*member) : double_target(member),  type(tDOUBLE) {};
 
-    inline void apply(Class& inst, bool val)        const { inst.*bool_target   = val; };
-    inline void apply(Class& inst, std::string val) const { inst.*string_target = val; };
-    inline void apply(Class& inst, int val)         const { inst.*int_target    = val; };
-    inline void apply(Class& inst, double val)      const { inst.*double_target = val; };
+    explicit field_mapper(bool Class::*member, bool default_val) :
+      bool_target(member), type(tBOOL), default_bool(default_val) {};
+    explicit field_mapper(std::string Class::*member, std::string default_val) :
+      string_target(member), type(tSTRING), default_string(default_val) {};
+    explicit field_mapper(int Class::*member, int default_val) :
+      int_target(member), type(tINT), default_int(default_val) {};
+    explicit field_mapper(double Class::*member, double default_val) :
+      double_target(member), type(tDOUBLE), default_double(default_val) {};
+
+    inline void apply(Class& inst, optional<int> val) const    { inst.*int_target = val.value_or(*default_int); }
+    inline void apply(Class& inst, optional<bool> val) const   { inst.*bool_target = val.value_or(*default_bool); }
+    inline void apply(Class& inst, optional<double> val) const { inst.*double_target = val.value_or(*default_double); }
+
+    // For backwards compatibility, applying a string will always fall back to
+    // an empty string if no default is available.
+    inline void apply(Class& inst, optional<std::string> val) const { 
+      inst.*string_target = val.value_or(default_string.value_or("")); 
+    }
   };
 
   template<class Class, typename ValueType>
   constexpr auto make_field_mapper(ValueType Class::*member) {
     return field_mapper<Class>(member);
+  };
+
+  template<class Class, typename ValueType>
+  constexpr auto make_field_mapper(ValueType Class::*member, ValueType default_val) {
+    return field_mapper<Class>(member, default_val);
   };
 }

--- a/include/gtfs/source.h
+++ b/include/gtfs/source.h
@@ -73,11 +73,11 @@ namespace gtfs {
       };
 
       field_map_t<frequency> frequency_fields = {
-        { "trip_id",       make_field_mapper(&frequency::trip_id)     },
-        { "start_time",    make_field_mapper(&frequency::start_time)  },
-        { "end_time",      make_field_mapper(&frequency::end_time)    },
-        { "headway_secs",  make_field_mapper(&frequency::headway)     },
-        { "exact_times",   make_field_mapper(&frequency::exact_times) }
+        { "trip_id",       make_field_mapper(&frequency::trip_id)            },
+        { "start_time",    make_field_mapper(&frequency::start_time)         },
+        { "end_time",      make_field_mapper(&frequency::end_time)           },
+        { "headway_secs",  make_field_mapper(&frequency::headway)            },
+        { "exact_times",   make_field_mapper(&frequency::exact_times, false) }
       };
 
       field_map_t<route> route_fields = {
@@ -101,31 +101,31 @@ namespace gtfs {
       };
 
       field_map_t<stop> stop_fields = {
-        { "stop_id",             make_field_mapper(&stop::id)                  },
-        { "stop_code",           make_field_mapper(&stop::code)                },
-        { "stop_name",           make_field_mapper(&stop::name)                },
-        { "stop_desc",           make_field_mapper(&stop::description)         },
-        { "stop_lat",            make_field_mapper(&stop::latitude)            },
-        { "stop_lon",            make_field_mapper(&stop::longitude)           },
-        { "zone_id",             make_field_mapper(&stop::zone_id)             },
-        { "stop_url",            make_field_mapper(&stop::stop_url)            },
-        { "location_type",       make_field_mapper(&stop::type)                },
-        { "parent_station",      make_field_mapper(&stop::parent_id)           },
-        { "stop_timezone",       make_field_mapper(&stop::timezone)            },
-        { "wheelchair_boarding", make_field_mapper(&stop::wheelchair_boarding) }
+        { "stop_id",             make_field_mapper(&stop::id)                     },
+        { "stop_code",           make_field_mapper(&stop::code)                   },
+        { "stop_name",           make_field_mapper(&stop::name)                   },
+        { "stop_desc",           make_field_mapper(&stop::description)            },
+        { "stop_lat",            make_field_mapper(&stop::latitude)               },
+        { "stop_lon",            make_field_mapper(&stop::longitude)              },
+        { "zone_id",             make_field_mapper(&stop::zone_id)                },
+        { "stop_url",            make_field_mapper(&stop::stop_url)               },
+        { "location_type",       make_field_mapper(&stop::type, 0)                },
+        { "parent_station",      make_field_mapper(&stop::parent_id)              },
+        { "stop_timezone",       make_field_mapper(&stop::timezone)               },
+        { "wheelchair_boarding", make_field_mapper(&stop::wheelchair_boarding, 0) }
       };
 
       field_map_t<stop_time> stop_time_fields = {
-        { "trip_id",             make_field_mapper(&stop_time::trip_id)        },
-        { "arrival_time",        make_field_mapper(&stop_time::arrival_time)   },
-        { "departure_time",      make_field_mapper(&stop_time::departure_time) },
-        { "stop_id",             make_field_mapper(&stop_time::stop_id)        },
-        { "stop_sequence",       make_field_mapper(&stop_time::index)          },
-        { "stop_headsign",       make_field_mapper(&stop_time::headsign)       },
-        { "pickup_type",         make_field_mapper(&stop_time::pickup_type)    },
-        { "drop_off_type",       make_field_mapper(&stop_time::dropoff_type)   },
-        { "shape_dist_traveled", make_field_mapper(&stop_time::distance)       },
-        { "timepoint",           make_field_mapper(&stop_time::timepoint)      }
+        { "trip_id",             make_field_mapper(&stop_time::trip_id)         },
+        { "arrival_time",        make_field_mapper(&stop_time::arrival_time)    },
+        { "departure_time",      make_field_mapper(&stop_time::departure_time)  },
+        { "stop_id",             make_field_mapper(&stop_time::stop_id)         },
+        { "stop_sequence",       make_field_mapper(&stop_time::index)           },
+        { "stop_headsign",       make_field_mapper(&stop_time::headsign)        },
+        { "pickup_type",         make_field_mapper(&stop_time::pickup_type, 0)  },
+        { "drop_off_type",       make_field_mapper(&stop_time::dropoff_type, 0) },
+        { "shape_dist_traveled", make_field_mapper(&stop_time::distance)        },
+        { "timepoint",           make_field_mapper(&stop_time::timepoint, true) }
       };
 
       field_map_t<transfer> transfer_fields = {
@@ -136,16 +136,16 @@ namespace gtfs {
       };
 
       field_map_t<trip> trip_fields {
-        { "route_id",              make_field_mapper(&trip::route_id)              },
-        { "service_id",            make_field_mapper(&trip::service_id)            },
-        { "trip_id",               make_field_mapper(&trip::id)                    },
-        { "trip_headsign",         make_field_mapper(&trip::headsign)              },
-        { "trip_short_name",       make_field_mapper(&trip::short_name)            },
-        { "direction_id",          make_field_mapper(&trip::direction_id)          },
-        { "block_id",              make_field_mapper(&trip::block_id)              },
-        { "shape_id",              make_field_mapper(&trip::shape_id)              },
-        { "wheelchair_accessible", make_field_mapper(&trip::wheelchair_accessible) },
-        { "bikes_allowed",         make_field_mapper(&trip::bikes_allowed)         }
+        { "route_id",              make_field_mapper(&trip::route_id)                 },
+        { "service_id",            make_field_mapper(&trip::service_id)               },
+        { "trip_id",               make_field_mapper(&trip::id)                       },
+        { "trip_headsign",         make_field_mapper(&trip::headsign)                 },
+        { "trip_short_name",       make_field_mapper(&trip::short_name)               },
+        { "direction_id",          make_field_mapper(&trip::direction_id)             },
+        { "block_id",              make_field_mapper(&trip::block_id)                 },
+        { "shape_id",              make_field_mapper(&trip::shape_id)                 },
+        { "wheelchair_accessible", make_field_mapper(&trip::wheelchair_accessible, 0) },
+        { "bikes_allowed",         make_field_mapper(&trip::bikes_allowed, 0)         }
       };
 
       // Parser objects for each type defined by GTFS.


### PR DESCRIPTION
Defaults are specified with an additional parameter to `make_field_mapper`, i.e.

    make_field_mapper(&stop_time::pickup_type, 0)

specifies an integer field `pickup_type` with default value 0. The type of the default value must match the field's property type.

This change uses std::optional (approved for c++17, but still std::experimental::optional in latest clang) to pass values into `field_mapper`. Passing an empty optional causes the field_mapper to attempt to use a default value.

Defaults for optional fields based on the [GTFS specification](https://developers.google.com/transit/gtfs/reference/) are added to `source.h`.

Especially since this is my first timetable PR and first c++ code I've hashed out in awhile, feedback welcome!