### PR TITLE
Features and bugfixes to support BART

### DIFF
--- a/include/datetime.h
+++ b/include/datetime.h
@@ -17,6 +17,16 @@ class DateTime {
       SECOND
     };
 
+    enum Weekday {
+      SUNDAY = 0,
+      MONDAY,
+      TUESDAY,
+      WEDNESDAY,
+      THURSDAY,
+      FRIDAY,
+      SATURDAY,
+    };
+
     static DateTime EPOCH;
 
 
@@ -85,6 +95,9 @@ class DateTime {
     // Return the string representation of this DateTime following the default
     // format `YYYYMMDD hh:mm:ss`.
     std::string to_string() const;
+    // Return the day of the week of this DateTime.
+    Weekday weekday() const;
+
 
     // Output the string returned by `to_string()` to the given stream.
     friend std::ostream& operator<<(std::ostream& os, const DateTime& dt) {

--- a/include/gtfs/agency.h
+++ b/include/gtfs/agency.h
@@ -25,6 +25,7 @@ namespace gtfs {
 
       agency() = default;
 
+      void post_init() { };
 
       // Standard stream output
       friend std::ostream& operator<<(std::ostream& os, const agency& a) {

--- a/include/gtfs/calendar.h
+++ b/include/gtfs/calendar.h
@@ -23,6 +23,7 @@ namespace gtfs {
 
       calendar() = default;
 
+      void post_init() { };
 
       // Standard stream output
       friend std::ostream& operator<<(std::ostream& os, const calendar& c) {

--- a/include/gtfs/calendar_date.h
+++ b/include/gtfs/calendar_date.h
@@ -15,6 +15,7 @@ namespace gtfs {
 
       calendar_date() = default;
 
+      void post_init() { };
 
       // Standard stream output
       friend std::ostream& operator<<(std::ostream& os, const calendar_date& cd) {

--- a/include/gtfs/csv_parser.h
+++ b/include/gtfs/csv_parser.h
@@ -123,6 +123,9 @@ namespace gtfs {
         while(current < line.size()) {
           // The loop iterates once per token. The parsing of the token is done
           // by the control branches inside of the loop.
+
+          // Skip leading whitespace in the token.
+          while(line[current] == ' ') current++;
           token_start = current;
 
           // If the first character is a quote, the token is "quote-escaped",

--- a/include/gtfs/csv_parser.h
+++ b/include/gtfs/csv_parser.h
@@ -107,11 +107,8 @@ namespace gtfs {
 
         std::istringstream header_stream(header_line);
         std::string column;
-        while(std::getline(header_stream, column, ',')) {
-          if (!column.empty() && column.back() == '\r')
-            column.pop_back();
+        while(_getline(header_stream, column, ','))
           columns.push_back(column);
-        }
 
         return columns;
       };
@@ -152,12 +149,16 @@ namespace gtfs {
         return tokens;
       };
 
-      std::istream &_getline(std::istream &input, std::string &out) {
-        std::getline(input, out);
+      std::istream &_getline(std::istream &input, std::string &out, char delim) {
+        std::getline(input, out, delim);
         // Handle CRLF strings, which are valid gtfs line endings.
         if (!out.empty() && out.back() == '\r')
           out.pop_back();
         return input;
       };
+
+      std::istream &_getline(std::istream &input, std::string &out) {
+        return _getline(input, out, '\n');
+      }
   };
 }

--- a/include/gtfs/csv_parser.h
+++ b/include/gtfs/csv_parser.h
@@ -48,7 +48,7 @@ namespace gtfs {
         object_list_t list;
         initialize();
         std::string row;
-        while(std::getline(this->input, row)) list.push_back(_parse_line(row));
+        while(_getline(this->input, row)) list.push_back(_parse_line(row));
         finish();
         return list;
       };
@@ -107,8 +107,11 @@ namespace gtfs {
 
         std::istringstream header_stream(header_line);
         std::string column;
-        while(std::getline(header_stream, column, ','))
+        while(std::getline(header_stream, column, ',')) {
+          if (!column.empty() && column.back() == '\r')
+            column.pop_back();
           columns.push_back(column);
+        }
 
         return columns;
       };
@@ -147,6 +150,14 @@ namespace gtfs {
         }
 
         return tokens;
+      };
+
+      std::istream &_getline(std::istream &input, std::string &out) {
+        std::getline(input, out);
+        // Handle CRLF strings, which are valid gtfs line endings.
+        if (!out.empty() && out.back() == '\r')
+          out.pop_back();
+        return input;
       };
   };
 }

--- a/include/gtfs/csv_parser.h
+++ b/include/gtfs/csv_parser.h
@@ -58,7 +58,7 @@ namespace gtfs {
 
       value_type next() {
         std::string row;
-        std::getline(this->input, row);
+        _getline(this->input, row);
         return _parse_line(row);
       };
 
@@ -103,7 +103,7 @@ namespace gtfs {
       std::vector<std::string> _parse_headers() {
         std::vector<std::string> columns;
         std::string header_line;
-        std::getline(this->input, header_line);
+        _getline(this->input, header_line);
 
         std::istringstream header_stream(header_line);
         std::string column;

--- a/include/gtfs/csv_parser.h
+++ b/include/gtfs/csv_parser.h
@@ -96,6 +96,7 @@ namespace gtfs {
           }
         }
 
+        inst.post_init();
         return inst;
       };
 

--- a/include/gtfs/fare_attribute.h
+++ b/include/gtfs/fare_attribute.h
@@ -21,6 +21,7 @@ namespace gtfs {
 
       fare_attribute() = default;
 
+      void post_init() { };
 
       // Standard stream output
       friend std::ostream& operator<<(std::ostream& os, const fare_attribute& fa) {

--- a/include/gtfs/fare_rule.h
+++ b/include/gtfs/fare_rule.h
@@ -19,6 +19,7 @@ namespace gtfs {
 
       fare_rule() = default;
 
+      void post_init() { };
 
       // Standard stream output
       friend std::ostream& operator<<(std::ostream& os, const fare_rule& fr) {

--- a/include/gtfs/feed_info.h
+++ b/include/gtfs/feed_info.h
@@ -21,6 +21,7 @@ namespace gtfs {
 
       feed_info() = default;
 
+      void post_init() { };
 
       // Standard stream output
       friend std::ostream& operator<<(std::ostream& os, const feed_info& fi) {

--- a/include/gtfs/frequency.h
+++ b/include/gtfs/frequency.h
@@ -19,6 +19,7 @@ namespace gtfs {
 
       frequency() = default;
 
+      void post_init() { };
 
       // Standard stream output
       friend std::ostream& operator<<(std::ostream& os, const frequency& f) {

--- a/include/gtfs/route.h
+++ b/include/gtfs/route.h
@@ -27,6 +27,9 @@ namespace gtfs {
 
       route() = default;
 
+      void post_init() {
+        if (short_name.empty()) short_name = long_name;
+      }
 
       // Standard stream output
       friend std::ostream& operator<<(std::ostream& os, const route& r) {

--- a/include/gtfs/route.h
+++ b/include/gtfs/route.h
@@ -29,6 +29,7 @@ namespace gtfs {
 
       void post_init() {
         if (short_name.empty()) short_name = long_name;
+        if (description.empty()) description = long_name;
       }
 
       // Standard stream output

--- a/include/gtfs/shape.h
+++ b/include/gtfs/shape.h
@@ -19,6 +19,7 @@ namespace gtfs {
 
       shape() = default;
 
+      void post_init() { };
 
       // Standard stream output
       friend std::ostream& operator<<(std::ostream& os, const shape& s) {

--- a/include/gtfs/stop.h
+++ b/include/gtfs/stop.h
@@ -33,6 +33,9 @@ namespace gtfs {
 
       stop() = default;
 
+      void post_init() {
+        if (code.empty()) code = id;
+      };
 
       // Standard stream output
       friend std::ostream& operator<<(std::ostream& os, const stop& s) {

--- a/include/gtfs/stop_time.h
+++ b/include/gtfs/stop_time.h
@@ -29,6 +29,7 @@ namespace gtfs {
 
       stop_time() = default;
 
+      void post_init() { };
 
       // Standard stream output
       friend std::ostream& operator<<(std::ostream& os, const stop_time& st) {

--- a/include/gtfs/transfer.h
+++ b/include/gtfs/transfer.h
@@ -17,6 +17,7 @@ namespace gtfs {
 
       transfer() = default;
 
+      void post_init() { };
 
       // Standard stream output
       friend std::ostream& operator<<(std::ostream& os, const transfer& t) {

--- a/include/gtfs/trip.h
+++ b/include/gtfs/trip.h
@@ -29,6 +29,7 @@ namespace gtfs {
 
       trip() = default;
 
+      void post_init() { };
 
       // Standard stream output
       friend std::ostream& operator<<(std::ostream& os, const trip& t) {

--- a/include/timetable.h
+++ b/include/timetable.h
@@ -10,7 +10,7 @@
 #include "visit.h"
 
 
-extern Timetable::Timetable tt;
+extern Timetable::Timetable *tt;
 
 
 ////

--- a/include/timetable/calendar.h
+++ b/include/timetable/calendar.h
@@ -11,19 +11,45 @@
 
 namespace Timetable {
   class Calendar {
-    using calendar_t = std::map<DateTime, std::unordered_map<std::string, bool>>;
+    using calendar_dates_t = std::map<DateTime, std::unordered_map<std::string, bool>>;
+    using calendar_t       = std::unordered_map<std::string, gtfs::calendar>;
+    using service_date_t   = std::unordered_map<std::string, DateTime>;
 
     public:
+      calendar_dates_t exceptions;
       calendar_t calendar;
+      service_date_t start_date;
+      service_date_t end_date;
 
       Calendar(gtfs::source& source) {
+        for(auto record : source.calendar_parser.all()) {
+          calendar[record.service_id] = record;
+          start_date[record.service_id] = DateTime::from_date(record.start_date);
+          end_date[record.service_id] = DateTime::from_date(record.end_date);
+        }
+
         for(auto cd : source.calendar_date_parser.all()) {
-          calendar[DateTime::from_date(cd.date)][cd.service_id] = (cd.exception_type == 1);
+          exceptions[DateTime::from_date(cd.date)][cd.service_id] = (cd.exception_type == 1);
         }
       };
 
       bool service_is_active(std::string service_id, DateTime date) {
-        return calendar[date.without_time()][service_id];
+        for (auto it = exceptions.find(date); it != exceptions.end(); ++it)
+          for (auto exception_active = it->second.find(service_id); exception_active != it->second.end();)
+            return exception_active->second;
+
+        if (date < start_date[service_id] || date > end_date[service_id])
+          return false;
+
+        switch (date.weekday()) {
+          case DateTime::MONDAY:    return calendar[service_id].monday;
+          case DateTime::TUESDAY:   return calendar[service_id].tuesday;
+          case DateTime::WEDNESDAY: return calendar[service_id].wednesday;
+          case DateTime::THURSDAY:  return calendar[service_id].thursday;
+          case DateTime::FRIDAY:    return calendar[service_id].friday;
+          case DateTime::SATURDAY:  return calendar[service_id].saturday;
+          case DateTime::SUNDAY:    return calendar[service_id].sunday;
+        }
       };
   };
 }

--- a/include/transport.h
+++ b/include/transport.h
@@ -46,6 +46,7 @@ class Transport {
     void start() {
       wamp->connect([&]() {
         _perform_actions();
+        std::cout << "Connected to " << router_url << std::endl;
       });
       while(true) transport.process();
     };
@@ -65,7 +66,7 @@ class Transport {
       action_queue.push_front(new WampCallAction(topic, arguments, argumentsKW, callback));
     };
     template<typename Proc>
-    void procedure(std::string const &topic, Proc p, TRegisterCallback callback = nullptr) {
+    void procedure(std::string const &topic, Proc p, TRegisterCallback callback = _registered) {
       action_queue.push_front(new WampRegisterAction<Proc>(topic, p, callback));
     };
 
@@ -76,4 +77,9 @@ class Transport {
     void _perform_actions() {
       for(auto* next_action : action_queue) next_action->perform(wamp);
     };
+
+    static void _registered(URI err) {
+      if (!err.empty())
+        std::cerr << "Registration with transport failed: " << err << std::endl;
+    }
 };

--- a/include/visit.h
+++ b/include/visit.h
@@ -17,11 +17,11 @@ class Visit {
     gtfs::trip&       trip;
     gtfs::route&      route;
 
-    Visit(gtfs::stop_time& st, DateTime arrival_dt, DateTime departure_dt, Timetable::Timetable& tt) :
+    Visit(gtfs::stop_time& st, DateTime arrival_dt, DateTime departure_dt, Timetable::Timetable *tt) :
         stop_time(st),
-        station(tt.stops[stop_time.stop_id]),
-        trip(tt.trips[stop_time.trip_id]),
-        route(tt.routes[trip.route_id]) {
+        station(tt->stops[stop_time.stop_id]),
+        trip(tt->trips[stop_time.trip_id]),
+        route(tt->routes[trip.route_id]) {
       arrival   = arrival_dt;
       departure = departure_dt;
     };

--- a/src/datetime.cc
+++ b/src/datetime.cc
@@ -120,3 +120,12 @@ std::string DateTime::to_string() const {
   snprintf(buf, 18, "%04d%02d%02d %02d:%02d:%02d", years, months, days, hours, minutes, seconds);
   return { buf };
 };
+
+DateTime::Weekday DateTime::weekday() const {
+  // Sakamoto's method
+  static int offset[] = {0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4};
+  short ytmp = years;
+  ytmp -= months < 3;
+  return static_cast<DateTime::Weekday>((ytmp + ytmp/4 - ytmp/100 + ytmp/400 +
+                                         offset[months-1] + days) % 7);
+}

--- a/src/datetime/resolve.cc
+++ b/src/datetime/resolve.cc
@@ -19,7 +19,7 @@ void DateTime::resolve() {
     .tm_sec   = seconds,
     // Defaulting `isdst` to -1 forces `mktime` to determine whether DST is
     // in effect for this datetime.
-    .tm_isdst = 0
+    .tm_isdst = -1
   };
 
   std::mktime(&t);

--- a/src/timetable.cc
+++ b/src/timetable.cc
@@ -1,19 +1,42 @@
 #include <iostream>
 #include <sstream>
+#include <unistd.h>
 #include <vector>
 
 #include "timetable.h"
 #include "transport.h"
 
 
-Timetable::Timetable tt("data/citybus");
+Timetable::Timetable *tt;
 
+static void abort_usage() {
+  std::cerr << "usage: timetable [-t transport_address] gtfs_directory\n";
+  exit(1);
+};
 
-int main() {
-  Transport t("ws://shark-nyc1.transio.us:8080/ws");
+int main(int argc, char * const argv[]) {
+  using namespace std::placeholders;
+
+  int ch;
+  std::string transport_address;
+  std::string gtfs_dir;
+  while ((ch = getopt(argc, argv, "-t:")) != -1) {
+    switch (ch) {
+      case 't': transport_address = optarg;
+      default:  break;
+    }
+  }
+
+  if (transport_address.empty())
+    transport_address = "ws://localhost:8080/ws";
+  if (argc == optind || (gtfs_dir = argv[optind]).empty())
+    abort_usage();
+
+  tt = new Timetable::Timetable(gtfs_dir);
+  Transport t(transport_address);
 
   create_indices();
-  tt.initialize();
+  tt->initialize();
 
   t.procedure("timetable.visits_before",              visits_before);
   t.procedure("timetable.visits_before_from_route",   visits_before_from_route);

--- a/src/timetable.cc
+++ b/src/timetable.cc
@@ -15,8 +15,6 @@ static void abort_usage() {
 };
 
 int main(int argc, char * const argv[]) {
-  using namespace std::placeholders;
-
   int ch;
   std::string transport_address;
   std::string gtfs_dir;

--- a/src/timetable/indices.cc
+++ b/src/timetable/indices.cc
@@ -3,15 +3,15 @@
 #include "gtfs.h"
 
 void create_indices() {
-  tt.add_index("station.departure", [](auto stid, auto st) -> std::string {
-    auto trip = tt.trips[st.trip_id];
+  tt->add_index("station.departure", [](auto stid, auto st) -> std::string {
+    auto trip = tt->trips[st.trip_id];
     std::string key = st.stop_id + st.departure_time;
     key += stid;
     return key;
   });
 
-  tt.add_index("route.station.departure", [](auto stid, auto st) -> std::string {
-    auto trip = tt.trips[st.trip_id];
+  tt->add_index("route.station.departure", [](auto stid, auto st) -> std::string {
+    auto trip = tt->trips[st.trip_id];
     std::string key = trip.route_id + st.stop_id + st.departure_time;
     key += stid;
     return key;

--- a/src/timetable/visits_after.cc
+++ b/src/timetable/visits_after.cc
@@ -3,8 +3,8 @@
 
 MsgPack do_visits_after(std::string stop_code, DateTime start, int count) {
   std::vector<Visit> results;
-  auto &index = tt.st_indices["station.departure"];
-  auto stop   = tt.stops[stop_code];
+  auto &index = tt->st_indices["station.departure"];
+  auto stop   = tt->stops[stop_code];
 
   auto lower_bound    = index.lower_bound(stop.id);
   auto initial_bound  = index.lower_bound(stop.id + start.time());
@@ -15,12 +15,12 @@ MsgPack do_visits_after(std::string stop_code, DateTime start, int count) {
     for(auto it = bound; ; ++it) {
       auto stop_time = *it->second;
       if(stop_time.stop_id != stop.id) break;
-      if(!tt.is_active(stop_time, today)) continue;
+      if(!tt->is_active(stop_time, today)) continue;
 
       auto departure_dt = DateTime(today.date(), stop_time.departure_time);
       departure_dt.resolve();
 
-      results.push_back({stop_time, departure_dt, departure_dt, tt});
+      results.push_back({stop_time, departure_dt, departure_dt, *tt});
 
       if((int) results.size() >= count) goto finish;
     }

--- a/src/timetable/visits_after.cc
+++ b/src/timetable/visits_after.cc
@@ -20,7 +20,7 @@ MsgPack do_visits_after(std::string stop_code, DateTime start, int count) {
       auto departure_dt = DateTime(today.date(), stop_time.departure_time);
       departure_dt.resolve();
 
-      results.push_back({stop_time, departure_dt, departure_dt, *tt});
+      results.push_back({stop_time, departure_dt, departure_dt, tt});
 
       if((int) results.size() >= count) goto finish;
     }

--- a/src/timetable/visits_after.cc
+++ b/src/timetable/visits_after.cc
@@ -13,7 +13,7 @@ MsgPack do_visits_after(std::string stop_code, DateTime start, int count) {
     auto bound = today.date() == start.date() ? initial_bound : lower_bound;
 
     for(auto it = bound; ; ++it) {
-      auto stop_time = *it->second;
+      auto &stop_time = *it->second;
       if(stop_time.stop_id != stop.id) break;
       if(!tt->is_active(stop_time, today)) continue;
 

--- a/src/timetable/visits_after_from_route.cc
+++ b/src/timetable/visits_after_from_route.cc
@@ -3,9 +3,9 @@
 
 MsgPack do_visits_after_from_route(std::string stop_code, DateTime start, std::string route_name, int count) {
   std::vector<Visit> results;
-  auto &index = tt.st_indices["route.station.departure"];
-  auto stop   = tt.stops[stop_code];
-  auto route  = std::find_if(tt.routes.begin(), tt.routes.end(), [route_name](auto pair) {
+  auto &index = tt->st_indices["route.station.departure"];
+  auto stop   = tt->stops[stop_code];
+  auto route  = std::find_if(tt->routes.begin(), tt->routes.end(), [route_name](auto pair) {
     if(pair.second.short_name == route_name) return true;
     return false;
   })->second;
@@ -19,12 +19,12 @@ MsgPack do_visits_after_from_route(std::string stop_code, DateTime start, std::s
     for(auto it = bound; ; ++it) {
       auto stop_time = *it->second;
       if(stop_time.stop_id != stop.id) break;
-      if(!tt.is_active(stop_time, today)) continue;
+      if(!tt->is_active(stop_time, today)) continue;
 
       auto departure_dt = DateTime(today.date(), stop_time.departure_time);
       departure_dt.resolve();
 
-      results.push_back({stop_time, departure_dt, departure_dt, tt});
+      results.push_back({stop_time, departure_dt, departure_dt, *tt});
 
       if((int) results.size() >= count) goto finish;
     }

--- a/src/timetable/visits_after_from_route.cc
+++ b/src/timetable/visits_after_from_route.cc
@@ -24,7 +24,7 @@ MsgPack do_visits_after_from_route(std::string stop_code, DateTime start, std::s
       auto departure_dt = DateTime(today.date(), stop_time.departure_time);
       departure_dt.resolve();
 
-      results.push_back({stop_time, departure_dt, departure_dt, *tt});
+      results.push_back({stop_time, departure_dt, departure_dt, tt});
 
       if((int) results.size() >= count) goto finish;
     }

--- a/src/timetable/visits_after_from_route.cc
+++ b/src/timetable/visits_after_from_route.cc
@@ -17,7 +17,7 @@ MsgPack do_visits_after_from_route(std::string stop_code, DateTime start, std::s
     auto bound = today.date() == start.date() ? initial_bound : lower_bound;
 
     for(auto it = bound; ; ++it) {
-      auto stop_time = *it->second;
+      auto &stop_time = *it->second;
       if(stop_time.stop_id != stop.id) break;
       if(!tt->is_active(stop_time, today)) continue;
 

--- a/src/timetable/visits_before.cc
+++ b/src/timetable/visits_before.cc
@@ -3,8 +3,8 @@
 
 MsgPack do_visits_before(std::string stop_code, DateTime end, int count) {
   std::vector<Visit> results;
-  auto &index = tt.st_indices["station.departure"];
-  auto stop   = tt.stops[stop_code];
+  auto &index = tt->st_indices["station.departure"];
+  auto stop   = tt->stops[stop_code];
 
   auto upper_bound    = index.upper_bound(Timetable::next(stop.id));
   auto initial_bound  = index.upper_bound(stop.id + end.time());
@@ -15,12 +15,12 @@ MsgPack do_visits_before(std::string stop_code, DateTime end, int count) {
     for(auto it = bound; ; --it) {
       auto stop_time = *it->second;
       if(stop_time.stop_id != stop.id) break;
-      if(!tt.is_active(stop_time, today)) continue;
+      if(!tt->is_active(stop_time, today)) continue;
 
       auto departure_dt = DateTime(today.date(), stop_time.departure_time);
       departure_dt.resolve();
 
-      results.push_back({stop_time, departure_dt, departure_dt, tt});
+      results.push_back({stop_time, departure_dt, departure_dt, *tt});
 
       if((int) results.size() >= count) goto finish;
     }

--- a/src/timetable/visits_before.cc
+++ b/src/timetable/visits_before.cc
@@ -13,7 +13,7 @@ MsgPack do_visits_before(std::string stop_code, DateTime end, int count) {
     auto bound = today.date() == end.date() ? initial_bound : upper_bound--;
 
     for(auto it = bound; ; --it) {
-      auto stop_time = *it->second;
+      auto &stop_time = *it->second;
       if(stop_time.stop_id != stop.id) break;
       if(!tt->is_active(stop_time, today)) continue;
 

--- a/src/timetable/visits_before.cc
+++ b/src/timetable/visits_before.cc
@@ -20,7 +20,7 @@ MsgPack do_visits_before(std::string stop_code, DateTime end, int count) {
       auto departure_dt = DateTime(today.date(), stop_time.departure_time);
       departure_dt.resolve();
 
-      results.push_back({stop_time, departure_dt, departure_dt, *tt});
+      results.push_back({stop_time, departure_dt, departure_dt, tt});
 
       if((int) results.size() >= count) goto finish;
     }

--- a/src/timetable/visits_before_from_route.cc
+++ b/src/timetable/visits_before_from_route.cc
@@ -17,7 +17,7 @@ MsgPack do_visits_before_from_route(std::string stop_code, DateTime end, std::st
     auto bound = today.date() == end.date() ? initial_bound : upper_bound--;
 
     for(auto it = bound; ; --it) {
-      auto stop_time = *it->second;
+      auto &stop_time = *it->second;
       if(stop_time.stop_id != stop.id) break;
       if(!tt->is_active(stop_time, today)) continue;
 

--- a/src/timetable/visits_before_from_route.cc
+++ b/src/timetable/visits_before_from_route.cc
@@ -3,9 +3,9 @@
 
 MsgPack do_visits_before_from_route(std::string stop_code, DateTime end, std::string route_name, int count) {
   std::vector<Visit> results;
-  auto &index = tt.st_indices["route.station.departure"];
-  auto stop   = tt.stops[stop_code];
-  auto route  = std::find_if(tt.routes.begin(), tt.routes.end(), [route_name](auto pair) {
+  auto &index = tt->st_indices["route.station.departure"];
+  auto stop   = tt->stops[stop_code];
+  auto route  = std::find_if(tt->routes.begin(), tt->routes.end(), [route_name](auto pair) {
     if(pair.second.short_name == route_name) return true;
     return false;
   })->second;
@@ -19,12 +19,12 @@ MsgPack do_visits_before_from_route(std::string stop_code, DateTime end, std::st
     for(auto it = bound; ; --it) {
       auto stop_time = *it->second;
       if(stop_time.stop_id != stop.id) break;
-      if(!tt.is_active(stop_time, today)) continue;
+      if(!tt->is_active(stop_time, today)) continue;
 
       auto departure_dt = DateTime(today.date(), stop_time.departure_time);
       departure_dt.resolve();
 
-      results.push_back({stop_time, departure_dt, departure_dt, tt});
+      results.push_back({stop_time, departure_dt, departure_dt, *tt});
 
       if((int) results.size() >= count) goto finish;
     }

--- a/src/timetable/visits_before_from_route.cc
+++ b/src/timetable/visits_before_from_route.cc
@@ -24,7 +24,7 @@ MsgPack do_visits_before_from_route(std::string stop_code, DateTime end, std::st
       auto departure_dt = DateTime(today.date(), stop_time.departure_time);
       departure_dt.resolve();
 
-      results.push_back({stop_time, departure_dt, departure_dt, *tt});
+      results.push_back({stop_time, departure_dt, departure_dt, tt});
 
       if((int) results.size() >= count) goto finish;
     }

--- a/src/timetable/visits_between.cc
+++ b/src/timetable/visits_between.cc
@@ -3,8 +3,8 @@
 
 MsgPack do_visits_between(std::string stop_code, DateTime start, DateTime end, int count) {
   std::vector<Visit> results;
-  auto &index = tt.st_indices["station.departure"];
-  auto stop   = tt.stops[stop_code];
+  auto &index = tt->st_indices["station.departure"];
+  auto stop   = tt->stops[stop_code];
 
   auto lower_bound    = index.lower_bound(stop.id);
   auto initial_bound  = index.lower_bound(stop.id + start.time());
@@ -15,14 +15,14 @@ MsgPack do_visits_between(std::string stop_code, DateTime start, DateTime end, i
     for(auto it = bound; ; ++it) {
       auto stop_time = *it->second;
       if(stop_time.stop_id != stop.id) break;
-      if(!tt.is_active(stop_time, today)) continue;
+      if(!tt->is_active(stop_time, today)) continue;
 
       auto departure_dt = DateTime(today.date(), stop_time.departure_time);
       departure_dt.resolve();
       if(departure_dt < start)  continue;
       if(departure_dt > end)    goto finish;
 
-      results.push_back({stop_time, departure_dt, departure_dt, tt});
+      results.push_back({stop_time, departure_dt, departure_dt, *tt});
 
       if((int) results.size() >= count) goto finish;
     }

--- a/src/timetable/visits_between.cc
+++ b/src/timetable/visits_between.cc
@@ -22,7 +22,7 @@ MsgPack do_visits_between(std::string stop_code, DateTime start, DateTime end, i
       if(departure_dt < start)  continue;
       if(departure_dt > end)    goto finish;
 
-      results.push_back({stop_time, departure_dt, departure_dt, *tt});
+      results.push_back({stop_time, departure_dt, departure_dt, tt});
 
       if((int) results.size() >= count) goto finish;
     }

--- a/src/timetable/visits_between.cc
+++ b/src/timetable/visits_between.cc
@@ -13,7 +13,7 @@ MsgPack do_visits_between(std::string stop_code, DateTime start, DateTime end, i
     auto bound = today.date() == start.date() ? initial_bound : lower_bound;
 
     for(auto it = bound; ; ++it) {
-      auto stop_time = *it->second;
+      auto &stop_time = *it->second;
       if(stop_time.stop_id != stop.id) break;
       if(!tt->is_active(stop_time, today)) continue;
 

--- a/src/timetable/visits_between_from_route.cc
+++ b/src/timetable/visits_between_from_route.cc
@@ -17,7 +17,7 @@ MsgPack do_visits_between_from_route(std::string stop_code, DateTime start, Date
     auto bound = today.date() == start.date() ? initial_bound : lower_bound;
 
     for(auto it = bound; ; ++it) {
-      auto stop_time = *it->second;
+      auto &stop_time = *it->second;
       if(stop_time.stop_id != stop.id) break;
       if(!tt->is_active(stop_time, today)) continue;
 

--- a/src/timetable/visits_between_from_route.cc
+++ b/src/timetable/visits_between_from_route.cc
@@ -26,7 +26,7 @@ MsgPack do_visits_between_from_route(std::string stop_code, DateTime start, Date
       if(departure_dt < start)  continue;
       if(departure_dt > end)    goto finish;
 
-      results.push_back({stop_time, departure_dt, departure_dt, *tt});
+      results.push_back({stop_time, departure_dt, departure_dt, tt});
 
       if((int) results.size() >= count) goto finish;
     }

--- a/src/timetable/visits_between_from_route.cc
+++ b/src/timetable/visits_between_from_route.cc
@@ -3,9 +3,9 @@
 
 MsgPack do_visits_between_from_route(std::string stop_code, DateTime start, DateTime end, std::string route_name, int count) {
   std::vector<Visit> results;
-  auto &index = tt.st_indices["route.station.departure"];
-  auto stop   = tt.stops[stop_code];
-  auto route  = std::find_if(tt.routes.begin(), tt.routes.end(), [route_name](auto pair) {
+  auto &index = tt->st_indices["route.station.departure"];
+  auto stop   = tt->stops[stop_code];
+  auto route  = std::find_if(tt->routes.begin(), tt->routes.end(), [route_name](auto pair) {
     if(pair.second.short_name == route_name) return true;
     return false;
   })->second;
@@ -19,14 +19,14 @@ MsgPack do_visits_between_from_route(std::string stop_code, DateTime start, Date
     for(auto it = bound; ; ++it) {
       auto stop_time = *it->second;
       if(stop_time.stop_id != stop.id) break;
-      if(!tt.is_active(stop_time, today)) continue;
+      if(!tt->is_active(stop_time, today)) continue;
 
       auto departure_dt = DateTime(today.date(), stop_time.departure_time);
       departure_dt.resolve();
       if(departure_dt < start)  continue;
       if(departure_dt > end)    goto finish;
 
-      results.push_back({stop_time, departure_dt, departure_dt, tt});
+      results.push_back({stop_time, departure_dt, departure_dt, *tt});
 
       if((int) results.size() >= count) goto finish;
     }


### PR DESCRIPTION
BART works! Here's an overview of the changes I made to Timetable to get it here:

New features:

- Added `post_init` member functions to all GTFS classes. These are called from `field_mapper` once a GTFS object is parsed, and are used to define substitutions. For example, BART don't have stop codes, but have reasonable stop IDs, so `gtfs::stop::post_init()` falls back to using `id` as `code` if no code exists.
- Support reading service availability from `calendar.txt`. This required adding logic to determine the weekday in `DateTime`.
- Runtime arguments for the server to connect to, and the GTFS source directory. This makes it much easier to switch agencies. I also print connection and error messages from the transport.

Bug fixes:

- Fixed a bug where every `Visit` in a result would get a reference to the same `stop_time` reference.
- Enabled DST prediction in `DateTime::resolve()`. I'm not entirely sure why this matters but it fixed off-by-one-hour errors for BART's data.
- The CSV parser can now handle CRLF line endings.

I've tested visits_between with Citybus haven't seen any regressions yet.